### PR TITLE
fix(dual-channel): embedded-items do not fixed when dual-channel container enters viewport

### DIFF
--- a/packages/dual-channel/dev/create-index-html.js
+++ b/packages/dual-channel/dev/create-index-html.js
@@ -358,6 +358,10 @@ body.archive .ct-container {
   src: url(/fonts.gstatic.com/s/roboto/v30/KFOlCnqEu92Fr1MmWUlfBBc4AMP6lQ.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
+#main-container {
+  min-height: 0 !important;
+  overflow-x: visible;
+}
 </style></head>
 <body class="post-template-default single single-post postid-3533 single-format-standard wp-custom-logo wp-embed-responsive stk--is-blocksy-theme 漫畫 theme-yellow ct-loading" data-link="type-2" data-prefix="single_blog_post" data-header="type-1:sticky" data-footer="type-1" itemscope="itemscope" itemtype="https://schema.org/Blog">
 <a class="skip-link show-on-focus" href="#main">

--- a/packages/dual-channel/src/app/components/sections-entry-points.js
+++ b/packages/dual-channel/src/app/components/sections-entry-points.js
@@ -54,6 +54,7 @@ class _HeadEntryPoint extends React.PureComponent {
         topOffset={this.props.topOffset}
         bottomOffset={this.props.bottomOffset}
         onPositionChange={this._handlePositionChange}
+        debug
       >
         <EntryPoint />
       </Waypoint>


### PR DESCRIPTION
react-waypoint container 會找他第一個可以 scroll 的祖先當作基準點，來判斷是否進入 viewport。
但因為目前的 css 會導致 dual-channel container 的祖先不是 window，而是 `div#main-container`，因為 dual-channel container 碰不到 `div#main-container` 的 top 和 bottom，所以無法觸發 onEnter 和 onLeave。
所以我先 hotfix 將 `div#main-container` 改成一個不能 scroll 的元素，所以 dual-channel 的 scrollableAncestor 就會變成 window，如此一來，就會恢復正常運作。

參考：
https://github.com/civiccc/react-waypoint#containing-elements-and-scrollableancestor